### PR TITLE
Add support (instead of fatal) for a jam misentered as Jam 0.

### DIFF
--- a/assets/sberrors.json
+++ b/assets/sberrors.json
@@ -103,7 +103,7 @@
         },
         "penaltyBadJam":
         {
-            "description": "Penalty entered for a jam greater than the highest jam on the Score Tab",
+            "description": "Penalty entered for an impossible jam (greater than the highest jam on the Score Tab, or prior to jam 1)",
             "events": [],
             "long": "A penalty was entered with a jam number higher than the maximum jam on the score sheet."
         },

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ let readPenalties = (workbook) => {
                     let code = codeText.v,
                         jam = jamText.v
 
-                    if(jam > sbData.periods[period].jams.length){
+                    if(jam > sbData.periods[period].jams.length || jam - 1 < 0){
                         // Error Check - jam number out of range
                         sbErrors.penalties.penaltyBadJam.events.push(
                             `Team: ${ucFirst(team)}, Skater: ${skaterNum.v}, Period: ${period}, Recorded Jam: ${jam}`


### PR DESCRIPTION
If someone mistypes 10 or 20 as 0, for a jam number, the app throws. 
Instead it should just consider it to be a bad jam number.  This does so,
and updates the "bad jam number" language to include the idea of jams that
are too low (instead of just too high).
