### PR TITLE
Implement CRG's JSON Roster Format

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,12 +55,19 @@ let createWindow = () => {
         {
             label: 'File',
             submenu: [
-                {   label: 'Export Roster to CRG',
+                {   label: 'Export Roster to CRG XML',
                     click: function() {
                         win.webContents.send('export-crg-roster')
                     },
                     enabled: false
                 },
+                {   label: 'Export Roster to CRG JSON (beta)',
+                    click: function() {
+                        win.webContents.send('export-crg-roster-json')
+                    },
+                    enabled: false
+                },
+
                 {   label: 'Save DerbyJSON',
                     click: function() {
                         win.webContents.send('save-derby-json')
@@ -203,7 +210,8 @@ app.on('activate',() => {
 
 ipc.on('enable-menu-items', () => {
     menu.items.find(x => x.label == 'File').submenu.items.find(x => x.label == 'Save DerbyJSON').enabled = true
-    menu.items.find(x => x.label == 'File').submenu.items.find(x => x.label == 'Export Roster to CRG').enabled = true
+    menu.items.find(x => x.label == 'File').submenu.items.find(x => x.label == 'Export Roster to CRG XML').enabled = true
+    menu.items.find(x => x.label == 'File').submenu.items.find(x => x.label == 'Export Roster to CRG JSON (beta)').enabled = true
 })
 
 ipc.on('error-thrown', (event, msg, url, lineNo, columnNo) => {

--- a/src/crg/crgtools.js
+++ b/src/crg/crgtools.js
@@ -1,0 +1,37 @@
+const uuid = require('uuid/v5');
+
+// use this guid as the namespace for the skater id
+const appNamespace = 'f291bfb9-74bf-4c5b-af33-902c19a74bea';
+
+function generateSkaterId(teamId, skaterName) {
+    const name = `${teamId}-${skaterName}`;
+    return uuid(name, appNamespace);
+}
+
+function extractTeamsFromSBData(sbData, teamList) {
+    return teamList.map(function(t) {
+        const teamName = `${sbData.teams[t].league || ''} ${sbData.teams[t].name}`;
+        const team = {
+            id: teamName,
+            name: teamName,
+            skaters: []
+        };
+
+        team.skaters = sbData.teams[t].persons.map(function(person) {
+            const skaterName = person.name;
+            return {
+                id: generateSkaterId(teamName, skaterName),
+                name: skaterName,
+                number: person.number,
+                flags: ""
+            }
+        });
+
+        return team;
+    });
+}
+
+
+module.exports = {
+    extractTeamsFromSBData
+}

--- a/src/crg/crgtools.js
+++ b/src/crg/crgtools.js
@@ -10,7 +10,14 @@ function generateSkaterId(teamId, skaterName) {
 
 function extractTeamsFromSBData(sbData, teamList) {
     return teamList.map(function(t) {
-        const teamName = `${sbData.teams[t].league || ''} ${sbData.teams[t].name}`;
+        let teamName;
+        
+        if(sbData.teams[t].league) {
+            teamName = `${sbData.teams[t].league} ${sbData.teams[t].name}`;
+        } else {
+            teamName = sbData.teams[t].name;
+        }
+
         const team = {
             id: teamName,
             name: teamName,

--- a/src/crg/exportJson.js
+++ b/src/crg/exportJson.js
@@ -1,0 +1,25 @@
+function exportJson(teams) {
+    const state = {};
+
+
+    teams.forEach((team) => {
+        const teamPrefix = `ScoreBoard.PreparedTeam(${team.id})`;
+
+        state[`${teamPrefix}.Id`] = team.id;
+        state[`${teamPrefix}.Name`] = team.name;
+
+        team.skaters.forEach((skater) => {
+            const skaterPrefix = `${teamPrefix}.Skater(${skater.id})`;
+
+            state[`${skaterPrefix}.Id`] = skater.id;
+            state[`${skaterPrefix}.Name`] = skater.name;
+            state[`${skaterPrefix}.Number`] = skater.number;
+            state[`${skaterPrefix}.Flags`] = skater.flags;
+        });
+    });
+
+
+    return { state };
+}
+
+module.exports = exportJson;

--- a/src/crg/exportXml.js
+++ b/src/crg/exportXml.js
@@ -1,0 +1,44 @@
+const { generateSkaterId } = require('./crgtools');
+
+const builder = require('xmlbuilder');
+
+function exportXml(teamData) {
+    const root = builder.create('document', {encoding: 'UTF-16'});
+    const teams = root.ele('Teams');
+
+    // Cargo cult boilerpplate - I don't know what this part is for,
+    // but it's in the original, so I'm leaving it in.
+    teams.ele('Reset ');
+    const transfer = teams.ele('Transfer');
+    let to = transfer.ele('To');
+    to.ele('Team1 ');
+    to.ele('Team2 ');
+    let from = transfer.ele('From');
+    from.ele('Team1 ');
+    from.ele('Team2');
+    const merge = teams.ele('Merge');
+    to = merge.ele('To');
+    to.ele('Team1 ');
+    to.ele('Team2 ');
+    from = merge.ele('From');
+    from.ele('Team1 ');
+    from.ele('Team2 ');
+
+    teamData.forEach(function(team) {
+        const teamEl = teams.ele('Team',  {'Id': team.id});
+        teamEl.ele('Name').dat(team.name);
+        teamEl.ele('Logo ');
+
+        team.skaters.forEach(function(skater) {
+            const skaterEl = teamEl.ele('Skater', {'Id': skater.id});
+
+            skaterEl.ele('Name').dat(skater.name)
+            skaterEl.ele('Number').dat(skater.number)
+            skaterEl.ele('Flags', {'empty': 'true'}).dat(skater.flags)
+        });
+    });
+
+    return root;
+}
+
+module.exports = exportXml;

--- a/src/index.js
+++ b/src/index.js
@@ -2011,7 +2011,7 @@ ipc.on('export-crg-roster-json', () => {
     const json = exportJsonRoster(teams);
 
     const blob = new Blob( [JSON.stringify(json, null, ' ')], { type: 'application/json' });
-    download(blob, sbFilename.split('.')[0] + '.xml');
+    download(blob, sbFilename.split('.')[0] + '.json');
 });
 
 let encode = (s) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1989,9 +1989,7 @@ holder.ondragend = () => {
 ipc.on('save-derby-json', () => {
     // Saves statsbook data to a JSON file
 
-    let data = encode( JSON.stringify(sbData, null, ' '))
-
-    let blob = new Blob( [ data ], { type: 'application/json' });
+    let blob = new Blob( [ JSON.stringify(sbData, null, ' ') ], { type: 'application/json' });
 
     download(blob, sbFilename.split('.')[0] + '.json');
 })
@@ -2012,8 +2010,7 @@ ipc.on('export-crg-roster-json', () => {
     const teams = extractTeamsFromSBData(sbData, teamList);
     const json = exportJsonRoster(teams);
 
-    const data = encode(JSON.stringify(json, null, ' '));
-    const blob = new Blob( [data], { type: 'application/json' });
+    const blob = new Blob( [JSON.stringify(json, null, ' ')], { type: 'application/json' });
     download(blob, sbFilename.split('.')[0] + '.xml');
 });
 
@@ -2024,6 +2021,7 @@ let encode = (s) => {
     }
     return new Uint16Array( out )
 }
+
 
 window.onerror = (msg, url, lineNo, columnNo) => {
     ipc.send('error-thrown', msg, url, lineNo, columnNo)

--- a/src/tools/download.js
+++ b/src/tools/download.js
@@ -1,0 +1,14 @@
+// probably should just install downloadjs, but this will do for this PR
+
+function download(data, filename) {
+    const url = URL.createObjectURL( data )
+    const link = document.createElement( 'a' )
+    link.setAttribute( 'href', url )
+    link.setAttribute( 'download', filename)
+
+    const e = document.createEvent( 'MouseEvents' )
+    e.initMouseEvent( 'click', true, true, window, 1, 0, 0, 0, 0, false, false, false, false, 0, null)
+    link.dispatchEvent( e )
+}
+
+module.exports = download;


### PR DESCRIPTION
As the new CRG Roster format has landed, add the ability to export a statsbook roster in the new format.

Additionally, this PR:

1. introduces some modularity - moving export, download code to standalone files, to start to move things away to the "one big code file" approach
2. ID generation process is now stable: the same skater on the same team will generate the same uuid, using a namespaced v5 uuid instead of a randomized v4 uuid.  This ensures that if a user generates a roster file from a file when they already have added one of the teams, they are (less likely) to get dupes in their CRG teams.
3. changes the derbyJSON export to export UTF-8 instead of UTF-16.  CRG didn't like the UTF-16 that encode() emitted, so I figured other clients may also dislike this encoding over UTF-8.

I can cherry pick out the menu item if you want to add the uuid and modularity changes before exposing the menu item.